### PR TITLE
fix java version of docker base image being too old

### DIFF
--- a/.github/workflows/build-aggregator.yaml
+++ b/.github/workflows/build-aggregator.yaml
@@ -39,7 +39,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=spoud_kafka-cost-control
+        run: mvn -B clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=spoud_kafka-cost-control -Dquarkus.container-image.build=true -Pfailsafe
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-aggregator.yaml
+++ b/.github/workflows/build-aggregator.yaml
@@ -39,7 +39,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=spoud_kafka-cost-control -Dquarkus.container-image.build=true -Pfailsafe
+        run: mvn -B clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=spoud_kafka-cost-control -Pfailsafe
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <skipITs>true</skipITs>
+        <skipITs>false</skipITs>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.8.3</quarkus.platform.version>
@@ -81,6 +81,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-docker</artifactId>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>

--- a/aggregator/src/main/docker/Dockerfile.jvm
+++ b/aggregator/src/main/docker/Dockerfile.jvm
@@ -77,7 +77,7 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.18
+FROM registry.access.redhat.com/ubi8/openjdk-21:1.18
 
 ENV LANGUAGE='en_US:en'
 

--- a/aggregator/src/main/resources/application.yaml
+++ b/aggregator/src/main/resources/application.yaml
@@ -83,4 +83,5 @@ quarkus:
         level: WARN
       "io.spoud.kcc":
         level: DEBUG
-
+  container-image:
+    build: true

--- a/aggregator/src/test/java/io/spoud/kcc/aggregator/stream/AppStartsTestIT.java
+++ b/aggregator/src/test/java/io/spoud/kcc/aggregator/stream/AppStartsTestIT.java
@@ -1,0 +1,11 @@
+package io.spoud.kcc.aggregator.stream;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+@QuarkusIntegrationTest
+public class AppStartsTestIT {
+    @Test
+    public void should_start_in_container() {
+    }
+}

--- a/aggregator/src/test/java/io/spoud/kcc/aggregator/stream/AppStartsTestIT.java
+++ b/aggregator/src/test/java/io/spoud/kcc/aggregator/stream/AppStartsTestIT.java
@@ -4,8 +4,9 @@ import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.Test;
 
 @QuarkusIntegrationTest
-public class AppStartsTestIT {
+class AppStartsTestIT {
     @Test
-    public void should_start_in_container() {
+    void should_start_in_container() {
+        // no assertion, just make sure the application is able to launch inside the container
     }
 }


### PR DESCRIPTION
Currently, launching the aggregator from the built container image fails with the following error:

> Caused by: java.lang.UnsupportedClassVersionError: io/spoud/kcc/aggregator/CostControlConfigProperties has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 61.0

To avoid such errors in the future, this PR also introduces a very simple integration test that verifies whether the containerized app is able to start.