### PR TITLE
return aggregation type info when querying known metrics

### DIFF
--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/data/MetricNameEntity.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/data/MetricNameEntity.java
@@ -4,4 +4,4 @@ import org.eclipse.microprofile.graphql.NonNull;
 
 import java.time.Instant;
 
-public record MetricNameEntity(@NonNull String metricName,@NonNull  Instant lastSeen) {}
+public record MetricNameEntity(@NonNull String metricName,@NonNull  Instant lastSeen, @NonNull String aggregationType) {}

--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/repository/MetricNameRepository.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/repository/MetricNameRepository.java
@@ -1,7 +1,9 @@
 package io.spoud.kcc.aggregator.repository;
 
 import io.spoud.kcc.aggregator.data.MetricNameEntity;
+import io.spoud.kcc.aggregator.stream.MetricReducer;
 import jakarta.enterprise.context.ApplicationScoped;
+import lombok.RequiredArgsConstructor;
 
 import java.time.Instant;
 import java.util.Comparator;
@@ -12,9 +14,11 @@ import java.util.stream.Collectors;
 
 /** Store all the metric names saw in the streams. */
 @ApplicationScoped
+@RequiredArgsConstructor
 public class MetricNameRepository {
 
   private final Map<String, Instant> metricNames = new ConcurrentHashMap<>(100);
+  private final MetricReducer metricReducer;
 
   public void addMetricName(String metricName, Instant metricTime) {
     metricNames.put(metricName, metricTime);
@@ -22,7 +26,7 @@ public class MetricNameRepository {
 
   public List<MetricNameEntity> getMetricNames() {
     return metricNames.entrySet().stream()
-        .map(entry -> new MetricNameEntity(entry.getKey(), entry.getValue()))
+        .map(entry -> new MetricNameEntity(entry.getKey(), entry.getValue(), metricReducer.getAggregationType(entry.getKey()).name()))
         .sorted(Comparator.comparing(MetricNameEntity::metricName))
         .collect(Collectors.toList());
   }


### PR DESCRIPTION
It would be good for debugging purposes if the GraphQL endpoint that returns known metrics also returned information on how they are aggregated (i.e. by summation or by maximization).