### PR TITLE
refactor, use smallrye-fault-tolerance, add tests

### DIFF
--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -68,6 +68,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-fault-tolerance</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kafka-streams</artifactId>
         </dependency>
         <dependency>

--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/stream/KafkaStreamManager.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/stream/KafkaStreamManager.java
@@ -2,14 +2,9 @@ package io.spoud.kcc.aggregator.stream;
 
 import io.quarkus.logging.Log;
 import io.quarkus.runtime.Quarkus;
-import io.quarkus.runtime.ShutdownEvent;
-import io.quarkus.runtime.StartupEvent;
 import io.smallrye.common.annotation.Identifier;
 import io.spoud.kcc.aggregator.CostControlConfigProperties;
-import jakarta.enterprise.event.Observes;
-import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
-import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -18,6 +13,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.BytesDeserializer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.faulttolerance.Retry;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -29,18 +25,20 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Singleton
-@RequiredArgsConstructor
 public class KafkaStreamManager {
-
     private final CostControlConfigProperties configProperties;
     private final KafkaStreams kafkaStreams;
+    private final Map<String, Object> kafkaConfig;
+    private final String applicationId;
 
-    @Inject
-    @Identifier("default-kafka-broker")
-    Map<String, Object> kafkaConfig;
-
-    @ConfigProperty(name = "kafka.application.id")
-    String applicationId;
+    public KafkaStreamManager(CostControlConfigProperties configProperties, KafkaStreams kafkaStreams,
+                              @Identifier("default-kafka-broker") Map<String, Object> kafkaConfig,
+                              @ConfigProperty(name = "kafka.application.id") String applicationId) {
+        this.configProperties = configProperties;
+        this.kafkaStreams = kafkaStreams;
+        this.kafkaConfig = kafkaConfig;
+        this.applicationId = applicationId;
+    }
 
     public void reprocess(Instant startTime) {
         Log.infov("Reprocessing requested for time {0}, stopping kafka stream", startTime);
@@ -67,19 +65,8 @@ public class KafkaStreamManager {
                             .map(entry -> entry.getKey() + ":" + entry.getValue().offset())
                             .collect(Collectors.joining(",")));
 
-            // try for 5min to reset the offsets
-            for (int i = 1; i <= 60; i++) {
-                try {
-                    adminClient.alterConsumerGroupOffsets(applicationId, toOffset).all().get();
-                    break;
-                } catch (ExecutionException ex1) {
-                    Log.warnv(
-                            "Attempt {0}: Unable to reset offset for consumer group \"{1}\", consumer group is certainly still attached, waiting a little bit before retrying",
-                            i, applicationId);
-                    Thread.sleep(5_000);
-                }
-            }
-        }catch (InterruptedException ex){
+            alterStreamsAppOffsets(adminClient, toOffset);
+        } catch (InterruptedException ex){
             Thread.currentThread().interrupt();
         } catch (ExecutionException ex) {
             Log.errorv(ex, "Unable to reset offsets for consumer-group {0}", applicationId);
@@ -87,10 +74,18 @@ public class KafkaStreamManager {
 
         Log.infov("Killing app so it reboots and reprocesses everything");
         Quarkus.asyncExit();
+    }
 
-        // DOESN'T WORK
-        //    Log.infov("Restarting the kafka stream application");
-        //    kafkaStreams.start();
+    @Retry(maxDuration = 5L * 60_000L, delay = 5_000L, retryOn = {ExecutionException.class})
+    public void alterStreamsAppOffsets(AdminClient adminClient, Map<TopicPartition, OffsetAndMetadata> toOffset) throws ExecutionException, InterruptedException {
+        try {
+            adminClient.alterConsumerGroupOffsets(applicationId, toOffset).all().get();
+        } catch (ExecutionException ex) {
+            // print the error before retrying
+            Log.warnv("Failed attempt to reset offset for consumer group \"{0}\": {1}",
+                    applicationId, ex.getCause().getMessage());
+            throw ex;
+        }
     }
 
     private Map<TopicPartition, OffsetAndMetadata> getOffsetForGivenTime(

--- a/aggregator/src/test/java/io/spoud/kcc/aggregator/stream/KafkaStreamManagerTest.java
+++ b/aggregator/src/test/java/io/spoud/kcc/aggregator/stream/KafkaStreamManagerTest.java
@@ -1,0 +1,74 @@
+package io.spoud.kcc.aggregator.stream;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AlterConsumerGroupOffsetsResult;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.KafkaStreams;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class KafkaStreamManagerTest {
+    KafkaStreamManager kafkaStreamManager;
+
+    public static final String TOPIC_RAW_TELEGRAF = "metrics-raw-telegraf";
+    public static final String TOPIC_PRICING_RULES = "pricing-rules";
+    public static final String TOPIC_CONTEXT_DATA = "context-data";
+    public static final String TOPIC_AGGREGATED = "aggregated";
+    public static final String TOPIC_AGGREGATED_TABLE_FRIENDLY = "aggregated-table-friendly";
+    public static final String APP_ID = "test";
+
+    @BeforeEach
+    void setUp() {
+        var configProperties = TestConfigProperties.builder()
+                .applicationId(APP_ID)
+                .topicAggregated(TOPIC_AGGREGATED)
+                .topicAggregatedTableFriendly(TOPIC_AGGREGATED_TABLE_FRIENDLY)
+                .topicPricingRules(TOPIC_PRICING_RULES)
+                .topicRawData(List.of(TOPIC_RAW_TELEGRAF))
+                .topicContextData(TOPIC_CONTEXT_DATA)
+                .metricsAggregations(Map.of("confluent_kafka_server_retained_bytes", "max"))
+                .build();
+        var kafkaStreams = Mockito.mock(KafkaStreams.class);
+        Mockito.when(kafkaStreams.close(Mockito.any(KafkaStreams.CloseOptions.class))).thenReturn(true);
+        kafkaStreamManager = new KafkaStreamManager(configProperties, kafkaStreams, Map.of(), APP_ID);
+    }
+
+    @Test
+    void should_rethrow_execution_exception() throws ExecutionException, InterruptedException {
+        var admin = Mockito.mock(AdminClient.class);
+        var result = Mockito.mock(AlterConsumerGroupOffsetsResult.class);
+        var future = Mockito.mock(KafkaFuture.class);
+        Mockito.when(admin.alterConsumerGroupOffsets(Mockito.eq(APP_ID), Mockito.anyMap()))
+                .thenReturn(result);
+        Mockito.when(result.all()).thenReturn(future);
+        Mockito.when(future.get()).thenThrow(new ExecutionException("Whoops", new RuntimeException("Something went wrong")));
+
+        assertThrows(ExecutionException.class, () -> kafkaStreamManager.alterStreamsAppOffsets(admin, Map.of()));
+    }
+
+    @Test
+    void should_alter_offsets() throws ExecutionException, InterruptedException {
+        var admin = Mockito.spy(AdminClient.class);
+        var result = Mockito.mock(AlterConsumerGroupOffsetsResult.class);
+        var future = Mockito.mock(KafkaFuture.class);
+
+        var toOffset = Map.of(new TopicPartition(TOPIC_RAW_TELEGRAF, 0), new OffsetAndMetadata(0));
+
+        Mockito.when(admin.alterConsumerGroupOffsets(Mockito.eq(APP_ID), Mockito.anyMap()))
+                .thenReturn(result);
+        Mockito.when(result.all()).thenReturn(future);
+        Mockito.when(future.get()).thenReturn(null);
+
+        assertDoesNotThrow(() -> kafkaStreamManager.alterStreamsAppOffsets(admin, toOffset));
+        Mockito.verify(admin).alterConsumerGroupOffsets(APP_ID, toOffset);
+    }
+}


### PR DESCRIPTION
I think there was a small bug in the original retry logic, where the [outer ExecutionException catch-block](https://github.com/spoud/kafka-cost-control/compare/feature/stream-manager-refactoring?expand=1#diff-16047acf1adcaa8b31018589b631d54d5071111f4134da938d6b79183d99e52dR71) would never be executed and thus no error would be reported if something goes wrong when altering group offsets. Hence I rewrote that part using the `@Retry` annotation.