### PR TITLE
add tags of scraped metrics to micrometer gauges for that metric

### DIFF
--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/repository/GaugeRepository.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/repository/GaugeRepository.java
@@ -5,6 +5,7 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import jakarta.enterprise.context.ApplicationScoped;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Map;
@@ -26,5 +27,11 @@ public class GaugeRepository {
         }).set(value);
     }
 
-    private record GaugeKey(String name, Tags tags) {}
+    public Map<GaugeKey, Double> getGaugeValues() {
+        var result = new ConcurrentHashMap<GaugeKey, Double>();
+        gauges.forEach((key, value) -> result.put(key, value.get()));
+        return result;
+    }
+
+    public record GaugeKey(String name, Tags tags) {}
 }

--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/stream/MetricEnricher.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/stream/MetricEnricher.java
@@ -24,6 +24,7 @@ import org.apache.kafka.streams.kstream.*;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 @ApplicationScoped
 @RequiredArgsConstructor
@@ -93,8 +94,8 @@ public class MetricEnricher {
                         value.getName(), value.getInitialMetricName()), Named.as("rekey-to-metric-name"))
                 .peek((key, value) -> {
                     try {
-                        var tags = Tags.of(value.getContext().entrySet().stream()
-                                .map(e -> Tag.of(e.getKey(), e.getValue()))
+                        var tags = Tags.of(Stream.concat(value.getContext().keySet().stream(), value.getTags().keySet().stream())
+                                .map(k -> Tag.of(k, value.getContext().getOrDefault(k, value.getTags().get(k))))
                                 .toList());
                         gaugeRepository.updateGauge("kcc_" + value.getInitialMetricName(), tags, value.getValue());
                     } catch (Exception e) {


### PR DESCRIPTION
If the context and the tags contain information with the same key, the value from context supersedes the tag value.