### PR TITLE
disable property that causes the operator to require cluster-level permissions

### DIFF
--- a/strimzi-operator/src/main/resources/application.yaml
+++ b/strimzi-operator/src/main/resources/application.yaml
@@ -20,6 +20,8 @@ quarkus:
     crd:
       # no need to apply CRDs, expect that Strimzi is already installed
       apply: false
+      # This is a build-time property, so we fix it to false here
+      validate: false
   container-image:
     build: true
 


### PR DESCRIPTION
It seems that QOSDK sets the [quarkus.operator-sdk.crd.validate](https://docs.quarkiverse.io/quarkus-operator-sdk/dev/includes/quarkus-operator-sdk.html#quarkus-operator-sdk_quarkus-operator-sdk-crd-validate) property to `true` by default, even though the [underlying JOSDK property](https://javaoperatorsdk.io/docs/faq/#q-how-can-i-run-an-operator-without-cluster-scope-rights) is switched-off by default.

This property makes the operator fail if it doesn't have cluster-scoped privileges to GET custom resources. It's also build time fixed, so we cannot override it later. Hopefully, switching it off will allow the operator to work with just namespace-scoped permissions.