### PR TITLE
when parsing metric values, fallback to first present key if "gauge" and "counter" values are not present

### DIFF
--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/stream/TelegrafDataWrapper.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/stream/TelegrafDataWrapper.java
@@ -66,8 +66,8 @@ public class TelegrafDataWrapper {
 
     /**
      * Get the value of the metric. If the metric is a gauge, the gauge value is returned. If the metric is a counter, the
-     * counter value is returned. If the metric is of another type (neither "gauge" nor "counter") keys are present among
-     * the fields, the first key (in alphabetical order) is returned. If no keys are present, 0 is returned.
+     * counter value is returned. If the metric is of another type (neither "gauge" nor "counter" keys are present among
+     * the fields), the first key (in alphabetical order) is returned. If no keys are present, 0 is returned.
      * In the latter case, a warning is logged.
      *
      * @return the value of the metric

--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/stream/TelegrafDataWrapper.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/stream/TelegrafDataWrapper.java
@@ -4,6 +4,7 @@ import io.quarkus.logging.Log;
 import io.spoud.kcc.aggregator.data.Metric;
 import io.spoud.kcc.aggregator.data.RawTelegrafData;
 import io.spoud.kcc.data.EntityType;
+import org.apache.commons.lang3.math.NumberUtils;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -79,7 +80,7 @@ public class TelegrafDataWrapper {
     private double getFirstPresentValue(String... keys) {
         for (String key : keys) {
             if (telegrafData.fields().containsKey(key)) {
-                return Double.parseDouble(String.valueOf(telegrafData.fields().get(key)));
+                return NumberUtils.toDouble(String.valueOf(telegrafData.fields().get(key)));
             }
         }
         // fallback to the first key in the map or 0 if no keys are present
@@ -90,7 +91,7 @@ public class TelegrafDataWrapper {
                 .min(Map.Entry.comparingByKey())
                 .map(Map.Entry::getValue)
                 .map(String::valueOf)
-                .map(Double::parseDouble)
+                .map(NumberUtils::toDouble)
                 .orElseGet(() -> {
                     Log.warnv("Cannot read value of metric \"{0}\". The fields are empty", telegrafData.name());
                     return 0.0;

--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/stream/TelegrafDataWrapper.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/stream/TelegrafDataWrapper.java
@@ -64,6 +64,14 @@ public class TelegrafDataWrapper {
         });
     }
 
+    /**
+     * Get the value of the metric. If the metric is a gauge, the gauge value is returned. If the metric is a counter, the
+     * counter value is returned. If the metric is of another type (neither "gauge" nor "counter") keys are present among
+     * the fields, the first key (in alphabetical order) is returned. If no keys are present, 0 is returned.
+     * In the latter case, a warning is logged.
+     *
+     * @return the value of the metric
+     */
     public double getValue() {
         return getFirstPresentValue(GAUGE_FIELD_NAME, COUNTER_FIELD_NAME);
     }
@@ -74,8 +82,19 @@ public class TelegrafDataWrapper {
                 return Double.parseDouble(String.valueOf(telegrafData.fields().get(key)));
             }
         }
-        Log.warnv("Cannot read value of metric \"{0}\". None of the following keys are present: {1}", telegrafData.name(), String.join(", ", keys));
-        return 0;
+        // fallback to the first key in the map or 0 if no keys are present
+        return telegrafData
+                .fields()
+                .entrySet()
+                .stream()
+                .min(Map.Entry.comparingByKey())
+                .map(Map.Entry::getValue)
+                .map(String::valueOf)
+                .map(Double::parseDouble)
+                .orElseGet(() -> {
+                    Log.warnv("Cannot read value of metric \"{0}\". The fields are empty", telegrafData.name());
+                    return 0.0;
+                });
     }
 
     public record AggregatedDataInfo(EntityType type, String name, Map<String, String> context) {

--- a/aggregator/src/test/java/io/spoud/kcc/aggregator/stream/TelegrafDataWrapperTest.java
+++ b/aggregator/src/test/java/io/spoud/kcc/aggregator/stream/TelegrafDataWrapperTest.java
@@ -1,0 +1,72 @@
+package io.spoud.kcc.aggregator.stream;
+
+import io.spoud.kcc.aggregator.data.RawTelegrafData;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TelegrafDataWrapperTest {
+
+    @Test
+    void get_gauge_value() {
+        var rawData = new RawTelegrafData(
+                Instant.now(),
+                "bytesin_total",
+                Map.of("gauge", 15.0, "ten_min_average", 10.0),
+                Map.of("env", "dev", "topic", "test"));
+        var wrapper = new TelegrafDataWrapper(rawData);
+
+        assertThat(wrapper.getValue()).isEqualTo(15.0);
+    }
+
+    @Test
+    void get_counter_value() {
+        var rawData = new RawTelegrafData(
+                Instant.now(),
+                "bytesin_total",
+                Map.of("counter", 15.0, "rate_per_sec", 0.1),
+                Map.of("env", "dev", "topic", "test"));
+        var wrapper = new TelegrafDataWrapper(rawData);
+
+        assertThat(wrapper.getValue()).isEqualTo(15.0);
+    }
+
+    @Test
+    void gauge_before_counter() {
+        var rawData = new RawTelegrafData(
+                Instant.now(),
+                "bytesin_total",
+                Map.of("gauge", 15.0, "counter", 10.0),
+                Map.of("env", "dev", "topic", "test"));
+        var wrapper = new TelegrafDataWrapper(rawData);
+
+        assertThat(wrapper.getValue()).isEqualTo(15.0);
+    }
+
+    @Test
+    void fallback_to_first_alphabetic_key() {
+        var rawData = new RawTelegrafData(
+                Instant.now(),
+                "bytesin_total",
+                Map.of("last_minute_mean", 15.0, "last_minute_variance", 1.0),
+                Map.of("env", "dev", "topic", "test"));
+        var wrapper = new TelegrafDataWrapper(rawData);
+
+        assertThat(wrapper.getValue()).isEqualTo(15.0);
+    }
+
+    @Test
+    void fallback_to_zero() {
+        var rawData = new RawTelegrafData(
+                Instant.now(),
+                "bytesin_total",
+                Map.of(),
+                Map.of("env", "dev", "topic", "test"));
+        var wrapper = new TelegrafDataWrapper(rawData);
+
+        assertThat(wrapper.getValue()).isEqualTo(0.0);
+    }
+}


### PR DESCRIPTION
There is an interesting feature in telegraf that allows us to do [windowed aggregations of metrics](https://github.com/influxdata/telegraf/tree/master/plugins/aggregators/basicstats) before pushing them to Kafka. This feature is particularly interesting when working with counters, as it would allow us to effectively turn monotonically increasing counters into gauge-style metrics by restricting the count to some time-window. A resulting metric could look like this:

```javascript
{"fields":{"counter_diff":2},"name":"kafka_network_requestmetrics_requestbytes_count_total" ...}
```

Currently, cost control does not support reading these arbitrary keys like `counter_diff` from the fields map. This PR aims to change that.