### PR TITLE
allow configuring prefixes/suffixes for context regexes

### DIFF
--- a/strimzi-operator/src/main/java/io/spoud/kcc/operator/OperatorConfig.java
+++ b/strimzi-operator/src/main/java/io/spoud/kcc/operator/OperatorConfig.java
@@ -5,6 +5,8 @@ import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 import jakarta.validation.constraints.NotBlank;
 
+import java.util.Optional;
+
 @ConfigMapping(prefix = "cc.strimzi.operator")
 public interface OperatorConfig {
     /**
@@ -64,4 +66,26 @@ public interface OperatorConfig {
     @WithName("topics.context-data")
     @NotBlank
     String contextDataTopic();
+
+    /**
+     * Context regex prefix. The regex is used to match the topic name to a context object.
+     * This prefix will be prepended to each generated regex. Use this if, for example, you also use MirrorMaker2
+     * which generates replicated topics with a prefix
+     * <p>
+     * For example, if for each topic with <topicname> MirrorMaker2 generates a replica called "eu-west-1.<topicname>",
+     * you could set this prefix to "(eu-west-1.)?" to match both, the prefixed and non-prefixed topics with the same context object.
+     */
+    @WithName("context-regex-prefix")
+    Optional<String> contextRegexPrefix();
+
+    /**
+     * Context regex suffix. The regex is used to match the topic name to a context object.
+     * This suffix will be appended to each generated regex. Use this if, for example, you also use MirrorMaker2
+     * which generates replicated topics with a suffix
+     * <p>
+     * For example, if for each topic with <topicname> MirrorMaker2 generates a replica called "<topicname>.eu-west-1",
+     * you could set this suffix to "(eu-west-1)?" to match both, the suffixed and non-suffixed topics with the same context object.
+     */
+    @WithName("context-regex-suffix")
+    Optional<String> contextRegexSuffix();
 }

--- a/strimzi-operator/src/main/java/io/spoud/kcc/operator/topics/KafkaTopicReconciler.java
+++ b/strimzi-operator/src/main/java/io/spoud/kcc/operator/topics/KafkaTopicReconciler.java
@@ -39,12 +39,14 @@ public class KafkaTopicReconciler implements Reconciler<KafkaTopic> {
     private void reconcileSingleTopic(KafkaTopic t) {
         Log.debugv("Reconciling KafkaTopic {0}", t.getMetadata().getName());
         var context = contextExtractor.getContextOfTopic(t);
+        var suffix = config.contextRegexSuffix().orElse("");
+        var prefix = config.contextRegexPrefix().orElse("");
         // publish the context to a Kafka topic
         var record = Record.of(t.getMetadata().getName(), ContextData.newBuilder()
                 .setCreationTime(Instant.now())
                 .setContext(context)
                 .setEntityType(EntityType.TOPIC)
-                .setRegex(t.getMetadata().getName().replaceAll("[.]", "[.]"))
+                .setRegex(String.format("%s%s%s", prefix, t.getMetadata().getName().replaceAll("[.]", "[.]"), suffix))
                 .build()
         );
         contextEmitter.send(record).whenComplete((unused, throwable) -> {

--- a/strimzi-operator/src/test/java/io/spoud/kcc/operator/DefaultTestProfile.java
+++ b/strimzi-operator/src/test/java/io/spoud/kcc/operator/DefaultTestProfile.java
@@ -5,10 +5,13 @@ import io.quarkus.test.junit.QuarkusTestProfile;
 import java.util.Map;
 
 public class DefaultTestProfile implements QuarkusTestProfile {
+    public static final String PREFIX = "(eu-west-1[.]|eu-east-1[.])?";
+
     @Override
     public Map<String, String> getConfigOverrides() {
         return Map.of(
                 "cc.strimzi.operator.topics.context-data", "context-data",
+                "cc.strimzi.operator.context-regex-prefix", PREFIX,
                 "quarkus.operator-sdk.crd.apply", "true", // the mock k8s server does not have strimzi CRDs, so we need to apply them
                 "kafka.linger.ms", "0",
                 "quarkus.log.category.\"io.spoud.kcc\".level", "DEBUG",

--- a/strimzi-operator/src/test/java/io/spoud/kcc/operator/OperatorTest.java
+++ b/strimzi-operator/src/test/java/io/spoud/kcc/operator/OperatorTest.java
@@ -33,6 +33,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.jboss.logmanager.MDC;
 import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
+import static io.spoud.kcc.operator.DefaultTestProfile.PREFIX;
 
 import java.time.Duration;
 import java.util.List;
@@ -145,7 +146,7 @@ class OperatorTest {
 
         // make sure that the context of TOPIC_NAME now contains a new reader
         var record = records.stream()
-                .filter(r -> TOPIC_NAME.equals(((GenericData.Record) r.value()).get("regex")))
+                .filter(r -> (PREFIX + TOPIC_NAME).equals(((GenericData.Record) r.value()).get("regex")))
                 .findFirst()
                 .orElseThrow();
         assertThatContextRecordMatchesTopic(record, getTopicInstance(TOPIC_NAME, TOPIC_APP),


### PR DESCRIPTION
This is important if we want the same context to target both the original topic and potential replica topics generated by mm2.