### PR TITLE
add some strimzi-friendly transformations

### DIFF
--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/CostControlConfigProperties.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/CostControlConfigProperties.java
@@ -35,4 +35,43 @@ public interface CostControlConfigProperties {
 
     @WithName("metrics.aggregations")
     Map<String, String> metricsAggregations();
+
+    /**
+     * This is a map of metric names to context keys. The value of the context key will be interpreted as a comma-separated list of values.
+     * The metric will be replaced with multiple metrics, one for each value in the list.
+     * Each new metric will have the same context as the original metric, except for the context key which will be set to contain
+     * just the respective element from the list. The value will be set to the original value divided by the number of elements in the list.
+     * <p>
+     * For example, if the incoming metric is {initialMetricName: "bytesin", context: {writers: "v1,v2", c2: "v3"}, value: 10} and this map contains
+     * {bytesin: writers}, then the original metric will be replaced by two metrics:
+     * {initialMetricName: "bytesin", context: {writers: "v1", c2: "v3"}, value: 5},
+     * {initialMetricName: "bytesin", context: {writers: "v2", c2: "v3"}, value: 5}
+     * <p>
+     * This is handy when you have a metric that represents usage of a resource by multiple entities, and you want to split the metric
+     * into individual metrics for each entity.
+     * <p>
+     * If a metric's context contains a single value for the context key, the metric will not be split.
+     * If a metric's context does not contain the context key, the metric also will not be split.
+     */
+    @WithName("metrics.transformations.splitValueAmongListMembers")
+    Map<String, String> splitValueAmongListMembers();
+
+    /**
+     * This is a map of metric names to context keys. Whenever a metric with the TOPIC entity type is encountered, it will be transformed
+     * into a metric with the PRINCIPAL entity type. The "name" of the metric will be placed into the context under the "topic" key.
+     * Then the "name" of the metric will be replaced with the value of the context key specified for this metric.
+     * <p>
+     * For example, if the incoming metric is
+     * {initialMetricName: "bytesProduced", context: {c1: "my-user", c2: "v2"}, value: 10, name: "my-topic", entityType: "TOPIC"}
+     * and this map contains {bytesProduced: c1}, then the original metric will be replaced by the following metric:
+     * {initialMetricName: "bytesProduced", context: {topic: "my-topic", c2: "v2"}, value: 10, name: "my-user", entityType: "PRINCIPAL"}
+     * <p>
+     * This transformation is applied *after* the splitValueAmongListMembers transformation, and together they form a powerful combination,
+     * that allows to split topic usage metrics among the principals using them.
+     * <p>
+     * If a matching metric is encountered, but the corresponding context does not have the specified key, the metric will not be transformed
+     * and a warning will be logged.
+     */
+    @WithName("metrics.transformations.topicMetricToPrincipalMetric")
+    Map<String, String> topicMetricToPrincipalMetric();
 }

--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/stream/MetricEnricher.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/stream/MetricEnricher.java
@@ -201,8 +201,8 @@ public class MetricEnricher {
                 .map(AggregatedData::getContext)
                 .map(context -> context.get(keyToSplitBy))
                 .map(value -> value.split(","))
-                .orElse(new String[]{});
-        if (splitBy.length == 0) {
+                .orElse(null);
+        if (splitBy == null) {
             return Stream.of(metric);
         }
         var valuePerSplit = metric.getValue() / splitBy.length;

--- a/aggregator/src/test/java/io/spoud/kcc/aggregator/stream/MetricEnricherTest.java
+++ b/aggregator/src/test/java/io/spoud/kcc/aggregator/stream/MetricEnricherTest.java
@@ -75,8 +75,7 @@ class MetricEnricherTest {
                 .topicRawData(List.of(TOPIC_RAW_TELEGRAF))
                 .topicContextData(TOPIC_CONTEXT_DATA)
                 .metricsAggregations(Map.of("confluent_kafka_server_retained_bytes", "max"))
-                .topicMetricToPrincipalMetric(Map.of("bytesin_transposable", "writers"))
-                .splitValueAmongListMembers(Map.of("bytesin_splittable", "writers"))
+                .splitValueAmongListMembers(Map.of("bytesin_transposable", "writers"))
                 .build();
         metricReducer = Mockito.spy(new MetricReducer(configProperties));
         metricRepository = new MetricNameRepository(metricReducer);
@@ -363,72 +362,33 @@ class MetricEnricherTest {
     }
 
     @Test
-    void should_apply_splitting_transformation() {
+    void should_turn_topic_metric_into_principal_metric() {
         contextDataStore.put("id1", new ContextData(Instant.now().minusSeconds(10), null, null,
                 EntityType.TOPIC, "spoud_.*", Map.of("writers", "alice,bob", "application", "flux-capacitor")));
-        final RawTelegrafData topicMetric = generateTopicRawTelegraf(Instant.now(), "bytesin_splittable", "spoud_topic_v1", 10.0);
+        final RawTelegrafData topicMetric = generateTopicRawTelegraf(Instant.now(), "bytesin_transposable", "spoud_topic_v1", 10.0);
 
         rawTelegrafDataTopic.pipeInput(topicMetric);
 
         assertThat(aggregatedTopic.getQueueSize()).isEqualTo(2);
         final List<AggregatedDataWindowed> list = aggregatedTopic.readValuesToList();
-        assertThat(list.stream().map(l -> l.getContext().get("writers")).collect(Collectors.toList()))
-                .containsExactlyInAnyOrder("alice", "bob");
-        assertThat(list.stream().map(l -> l.getContext().get("application")).collect(Collectors.toSet()))
-                .containsOnly("flux-capacitor");
-        assertThat(list.stream().map(AggregatedDataWindowed::getValue)).containsExactly(5.0, 5.0);
-        assertThat(list.stream().map(AggregatedDataWindowed::getName)).containsExactly("spoud_topic_v1", "spoud_topic_v1");
-    }
-
-    @Test
-    void should_not_split_metric_without_right_context() {
-        final RawTelegrafData topicMetric = generateTopicRawTelegraf(Instant.now(), "bytesin_splittable", "nocontext-topic", 10.0);
-
-        rawTelegrafDataTopic.pipeInput(topicMetric);
-
-        assertThat(aggregatedTopic.getQueueSize()).isEqualTo(1);
-        final List<AggregatedDataWindowed> list = aggregatedTopic.readValuesToList();
-        assertThat(list).hasSize(1);
-        assertThat(list.getFirst().getValue()).isEqualTo(10.0);
-    }
-
-    @Test
-    void should_not_split_metric_given_singleton_list() {
-        contextDataStore.put("id1", new ContextData(Instant.now().minusSeconds(10), null, null,
-                EntityType.TOPIC, "spoud_.*", Map.of("writers", "alice", "application", "flux-capacitor")));
-        final RawTelegrafData topicMetric = generateTopicRawTelegraf(Instant.now(), "bytesin_splittable", "spoud_topic_v1", 10.0);
-
-        rawTelegrafDataTopic.pipeInput(topicMetric);
-
-        assertThat(aggregatedTopic.getQueueSize()).isEqualTo(1);
-        final List<AggregatedDataWindowed> list = aggregatedTopic.readValuesToList();
-        assertThat(list).hasSize(1);
-        assertThat(list.getFirst().getValue()).isEqualTo(10.0);
-    }
-
-    @Test
-    void should_turn_topic_metric_into_principal_metric() {
-        contextDataStore.put("id1", new ContextData(Instant.now().minusSeconds(10), null, null,
-                EntityType.TOPIC, "spoud_.*", Map.of("writers", "alice", "application", "flux-capacitor")));
-        final RawTelegrafData topicMetric = generateTopicRawTelegraf(Instant.now(), "bytesin_transposable", "spoud_topic_v1", 10.0);
-
-        rawTelegrafDataTopic.pipeInput(topicMetric);
-
-        // make sure that the metric that comes out is of type PRINCIPAL and has name "alice"
-        assertThat(aggregatedTopic.getQueueSize()).isEqualTo(1);
-        final List<AggregatedDataWindowed> list = aggregatedTopic.readValuesToList();
-        assertThat(list).hasSize(1);
+        assertThat(list).hasSize(2);
         assertThat(list.getFirst().getEntityType()).isEqualTo(EntityType.PRINCIPAL);
         assertThat(list.getFirst().getName()).isEqualTo("alice");
         assertThat(list.getFirst().getContext()).containsOnlyKeys("topic", "application");
         assertThat(list.getFirst().getContext()).containsEntry("topic", "spoud_topic_v1");
-        assertThat(list.getFirst().getValue()).isEqualTo(10);
+        assertThat(list.getFirst().getValue()).isEqualTo(5);
+
+        assertThat(list.getLast().getEntityType()).isEqualTo(EntityType.PRINCIPAL);
+        assertThat(list.getLast().getName()).isEqualTo("bob");
+        assertThat(list.getLast().getContext()).containsOnlyKeys("topic", "application");
+        assertThat(list.getLast().getContext()).containsEntry("topic", "spoud_topic_v1");
+        assertThat(list.getLast().getValue()).isEqualTo(5);
     }
 
     @Test
-    void should_turn_not_transform_topic_into_principal_metric_if_principal_context_missing() {
+    void should_not_transform_topic_into_principal_metric_if_principal_context_missing() {
         contextDataStore.put("id1", new ContextData(Instant.now().minusSeconds(10), null, null,
-                EntityType.TOPIC, "spoud_.*", Map.of("readers", "alice", "application", "flux-capacitor")));
+                EntityType.TOPIC, "spoud_.*", Map.of("readers", "alice,bob", "application", "flux-capacitor"))); // we replaced "writers" with "readers" (above we configured the application to only split among "writers")
         final RawTelegrafData topicMetric = generateTopicRawTelegraf(Instant.now(), "bytesin_transposable", "spoud_topic_v1", 10.0);
 
         rawTelegrafDataTopic.pipeInput(topicMetric);
@@ -439,7 +399,7 @@ class MetricEnricherTest {
         assertThat(list.getFirst().getEntityType()).isEqualTo(EntityType.TOPIC);
         assertThat(list.getFirst().getName()).isEqualTo("spoud_topic_v1");
         assertThat(list.getFirst().getContext()).containsOnlyKeys("readers", "application");
-        assertThat(list.getFirst().getContext()).containsEntry("readers", "alice");
+        assertThat(list.getFirst().getContext()).containsEntry("readers", "alice,bob");
         assertThat(list.getFirst().getValue()).isEqualTo(10);
     }
 

--- a/aggregator/src/test/java/io/spoud/kcc/aggregator/stream/TestConfigProperties.java
+++ b/aggregator/src/test/java/io/spoud/kcc/aggregator/stream/TestConfigProperties.java
@@ -17,6 +17,8 @@ public class TestConfigProperties implements CostControlConfigProperties {
     private List<String> topicRawData;
     private String topicAggregated;
     private Map<String, String> metricsAggregations;
+    private Map<String, String> topicMetricToPrincipalMetric;
+    private Map<String, String> splitValueAmongListMembers;
 
     @Override
     public String adminPassword() {
@@ -56,5 +58,15 @@ public class TestConfigProperties implements CostControlConfigProperties {
     @Override
     public Map<String, String> metricsAggregations() {
         return metricsAggregations;
+    }
+
+    @Override
+    public Map<String, String> topicMetricToPrincipalMetric() {
+        return topicMetricToPrincipalMetric;
+    }
+
+    @Override
+    public Map<String, String> splitValueAmongListMembers() {
+        return splitValueAmongListMembers;
     }
 }

--- a/aggregator/src/test/java/io/spoud/kcc/aggregator/stream/TestConfigProperties.java
+++ b/aggregator/src/test/java/io/spoud/kcc/aggregator/stream/TestConfigProperties.java
@@ -17,7 +17,6 @@ public class TestConfigProperties implements CostControlConfigProperties {
     private List<String> topicRawData;
     private String topicAggregated;
     private Map<String, String> metricsAggregations;
-    private Map<String, String> topicMetricToPrincipalMetric;
     private Map<String, String> splitValueAmongListMembers;
 
     @Override
@@ -61,12 +60,7 @@ public class TestConfigProperties implements CostControlConfigProperties {
     }
 
     @Override
-    public Map<String, String> topicMetricToPrincipalMetric() {
-        return topicMetricToPrincipalMetric;
-    }
-
-    @Override
-    public Map<String, String> splitValueAmongListMembers() {
+    public Map<String, String> splitTopicMetricAmongPrincipals() {
         return splitValueAmongListMembers;
     }
 }

--- a/docs/manual/src/cost_control_config.adoc
+++ b/docs/manual/src/cost_control_config.adoc
@@ -31,3 +31,29 @@ Note that these settings may only be set in an `application.properties` file, an
 This is due to the fact that Quarkus cannot unambiguously map environment variable names to property names if said
 property names contain user-defined parts (like `confluent_kafka_server_retained_bytes` in the example above).
 For more information, see https://quarkus.io/guides/config-reference#environment-variables[the relevant section of the Quarkus documentation].
+
+==== Configuring transformations
+
+Currently, there is one kind of transformation that can be added to the metrics processing pipeline: `splitTopicMetricAmongPrincipals`.
+This transformation is configured by supplying a map of metric names to context keys in application.properties. For example:
+
+```properties
+cc.metrics.transformations.splitMetricAmongPrincipals={bytesin:'writers',bytesout:'readers'}
+```
+
+This will expect `bytesin` metrics to have a `writers` key in their context, which should be a comma-separated list of principals (e.g. applications, teams, ...)
+that can write to this topic. When a `bytesin` metric for any topic is encountered, the metric will be replaced with `n` metrics (where `n` is the length of the `writers` list
+in that metric's context). The name of the topic will be moved into that metric's context under the `topic` key and the name of a principal from the `writers`
+list will move into the metric's `name` field. The value of each generated metric will be the value of the original metric divided by `n`.
+
+In effect this takes a single metric that says "90 kb have been written to topic ABC by writers X,Y,Z" and transforms it into 3 metrics:
+
+- Principal X wrote 30 kb to topic ABC
+- Principal Y wrote 30 kb to topic ABC
+- Principal Z wrote 30 kb to topic ABC
+
+The advantage over the original metric is that each such transformed metric will be put into its own database row, which will make it easier to aggregate by principal
+(e.g. answer questions like "how much did principal X produce in the past month"). This type of transformation is especially relevant when doing cost control based on vanilla
+Kafka broker metrics (as is the case in Strimzi deployments, for example), because here only topic-level metrics are generated natively. This transformation allows to turn
+these topic-focused metrics into principal-focused ones.
+


### PR DESCRIPTION
When doing cost-control with Strimzi, we are only able to generate topic metrics (due to there not being a concept of "principals" that we can track via broker metrics). We can attach a context to each topic metric that tells us which kafka users can read/write from/to that topic. Processing these metrics downstream will be much easier if we do two things in the stream:

1. Divide a topic metric (e.g. `bytes in`) evenly among all relevant users (1 topic metric is mapped to n topic metrics. In each of them, the value is `original_value / n`)
2. Transform each topic metric into a principal metric by moving the topic name into the context and putting the principal name into the record's "name" field