### PR TITLE
remove gauges that haven't been updated long enough

### DIFF
--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/CostControlConfigProperties.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/CostControlConfigProperties.java
@@ -5,6 +5,7 @@ import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -17,7 +18,7 @@ public interface CostControlConfigProperties {
 
     @WithName("aggregation-window-size")
     @WithDefault("PT1H")
-    String aggregationWindowSize();
+    Duration aggregationWindowSize();
 
     @WithName("topics.raw-data")
     @NotNull

--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/repository/GaugeRepository.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/repository/GaugeRepository.java
@@ -9,6 +9,8 @@ import io.quarkus.logging.Log;
 import io.quarkus.scheduler.Scheduled;
 import io.spoud.kcc.aggregator.CostControlConfigProperties;
 import jakarta.enterprise.context.ApplicationScoped;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -18,9 +20,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /** Store all the metric values (gauges) observed while running the application. */
 @ApplicationScoped
 public class GaugeRepository {
-    private final Map<GaugeKey, AtomicDouble> gauges = new ConcurrentHashMap<>();
-    private final Map<GaugeKey, Instant> gaugeTimeouts = new ConcurrentHashMap<>();
-    private final Map<GaugeKey, Meter.Id> gaugeIds = new ConcurrentHashMap<>();
+    private final Map<GaugeKey, GaugeInfo> gauges = new ConcurrentHashMap<>();
     private final MeterRegistry meterRegistry;
     private final Duration gaugeTimeout;
     private Instant currentTime = Instant.MIN;
@@ -28,41 +28,37 @@ public class GaugeRepository {
     public GaugeRepository(MeterRegistry meterRegistry, CostControlConfigProperties configProperties) {
         this.meterRegistry = meterRegistry;
         // If a gauge is not updated for more than the aggregation window size plus 30-second grace period, that metric is considered unavailable.
-        this.gaugeTimeout = Duration.parse(configProperties.aggregationWindowSize()).plus(Duration.ofSeconds(30));
+        this.gaugeTimeout = configProperties.aggregationWindowSize().plus(Duration.ofSeconds(30));
     }
 
     public void updateGauge(String name, Tags tags, double value, Instant eventTime) {
         var key = new GaugeKey(name, tags);
         updateCurrentTime(eventTime);
-        gaugeTimeouts.put(key, getCurrentTime().plus(gaugeTimeout));
         gauges.computeIfAbsent(key, g -> {
             var atomicDouble = new AtomicDouble(value);
             var id = Gauge.builder(name, atomicDouble, AtomicDouble::get).tags(tags).register(meterRegistry).getId();
-            gaugeIds.put(key, id);
-            return atomicDouble;
-        }).set(value);
+            var timeout = getCurrentTime().plus(gaugeTimeout);
+            return new GaugeInfo(id, atomicDouble, timeout);
+        }).updateValue(value);
     }
 
     public Map<GaugeKey, Double> getGaugeValues() {
         var result = new ConcurrentHashMap<GaugeKey, Double>();
-        gauges.forEach((key, value) -> result.put(key, value.get()));
+        gauges.forEach((key, value) -> result.put(key, value.gaugeValue.get()));
         return result;
     }
 
     @Scheduled(every = "60s", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     public void removeExpiredGauges() {
         var now = getCurrentTime();
-        gaugeTimeouts.entrySet().removeIf(entry -> {
-            if (entry.getValue().isBefore(now)) {
+        gauges.entrySet().removeIf(entry -> {
+            if (entry.getValue().getTimeout().isBefore(now)) {
                 Log.infof("Gauge '%s' with tags '%s' has expired and will be removed",
                         entry.getKey().name, entry.getKey().tags);
-                gauges.remove(entry.getKey());
-                var id = gaugeIds.remove(entry.getKey());
-                if (id != null)
-                    meterRegistry.remove(id);
-                return true; // Remove the entry from gaugeTimeouts
+                meterRegistry.remove(entry.getValue().getId());
+                return true;
             }
-            return false; // Keep the entry
+            return false;
         });
     }
 
@@ -75,4 +71,17 @@ public class GaugeRepository {
     }
 
     public record GaugeKey(String name, Tags tags) {}
+
+    @Data
+    @AllArgsConstructor
+    public class GaugeInfo {
+        private final Meter.Id id;
+        private final AtomicDouble gaugeValue;
+        private Instant timeout;
+
+        public void updateValue(double value) {
+            gaugeValue.set(value);
+            timeout = getCurrentTime().plus(gaugeTimeout);
+        }
+    }
 }

--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/repository/GaugeRepository.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/repository/GaugeRepository.java
@@ -2,27 +2,43 @@ package io.spoud.kcc.aggregator.repository;
 
 import com.google.common.util.concurrent.AtomicDouble;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
+import io.quarkus.logging.Log;
+import io.quarkus.scheduler.Scheduled;
+import io.spoud.kcc.aggregator.CostControlConfigProperties;
 import jakarta.enterprise.context.ApplicationScoped;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /** Store all the metric values (gauges) observed while running the application. */
-@RequiredArgsConstructor
 @ApplicationScoped
 public class GaugeRepository {
     private final Map<GaugeKey, AtomicDouble> gauges = new ConcurrentHashMap<>();
+    private final Map<GaugeKey, Instant> gaugeTimeouts = new ConcurrentHashMap<>();
+    private final Map<GaugeKey, Meter.Id> gaugeIds = new ConcurrentHashMap<>();
     private final MeterRegistry meterRegistry;
+    private final Duration gaugeTimeout;
+    private Instant currentTime = Instant.MIN;
 
-    public void updateGauge(String name, Tags tags, double value) {
+    public GaugeRepository(MeterRegistry meterRegistry, CostControlConfigProperties configProperties) {
+        this.meterRegistry = meterRegistry;
+        // If a gauge is not updated for more than the aggregation window size plus 30-second grace period, that metric is considered unavailable.
+        this.gaugeTimeout = Duration.parse(configProperties.aggregationWindowSize()).plus(Duration.ofSeconds(30));
+    }
+
+    public void updateGauge(String name, Tags tags, double value, Instant eventTime) {
         var key = new GaugeKey(name, tags);
+        updateCurrentTime(eventTime);
+        gaugeTimeouts.put(key, getCurrentTime().plus(gaugeTimeout));
         gauges.computeIfAbsent(key, g -> {
             var atomicDouble = new AtomicDouble(value);
-            Gauge.builder(name, atomicDouble, AtomicDouble::get).tags(tags).register(meterRegistry);
+            var id = Gauge.builder(name, atomicDouble, AtomicDouble::get).tags(tags).register(meterRegistry).getId();
+            gaugeIds.put(key, id);
             return atomicDouble;
         }).set(value);
     }
@@ -31,6 +47,31 @@ public class GaugeRepository {
         var result = new ConcurrentHashMap<GaugeKey, Double>();
         gauges.forEach((key, value) -> result.put(key, value.get()));
         return result;
+    }
+
+    @Scheduled(every = "60s", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
+    public void removeExpiredGauges() {
+        var now = getCurrentTime();
+        gaugeTimeouts.entrySet().removeIf(entry -> {
+            if (entry.getValue().isBefore(now)) {
+                Log.infof("Gauge '%s' with tags '%s' has expired and will be removed",
+                        entry.getKey().name, entry.getKey().tags);
+                gauges.remove(entry.getKey());
+                var id = gaugeIds.remove(entry.getKey());
+                if (id != null)
+                    meterRegistry.remove(id);
+                return true; // Remove the entry from gaugeTimeouts
+            }
+            return false; // Keep the entry
+        });
+    }
+
+    private Instant getCurrentTime() {
+        return currentTime;
+    }
+
+    private void updateCurrentTime(Instant eventTime) {
+        this.currentTime = eventTime.isAfter(currentTime) ? eventTime : currentTime;
     }
 
     public record GaugeKey(String name, Tags tags) {}

--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/stream/MetricEnricher.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/stream/MetricEnricher.java
@@ -108,7 +108,7 @@ public class MetricEnricher {
                                 .map(k -> Tag.of(k, value.getContext().getOrDefault(k, value.getTags().get(k))))
                                 .toList());
                         tags = tags.and(value.getEntityType().name().toLowerCase(), value.getName());
-                        gaugeRepository.updateGauge("kcc_" + value.getInitialMetricName(), tags, value.getValue());
+                        gaugeRepository.updateGauge("kcc_" + value.getInitialMetricName(), tags, value.getValue(), value.getStartTime());
                     } catch (Exception e) {
                         Log.warnv("Error updating gauge for metric {0} and tags {1}", value.getName(), value.getTags(), e);
                     }

--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/stream/MetricEnricher.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/stream/MetricEnricher.java
@@ -50,7 +50,7 @@ public class MetricEnricher {
     public Topology metricEnricherTopology() {
         Log.infov("Will start MetricEnricher for topics: {0}", configProperties.rawTopics());
 
-        TimeWindows tumblingWindow = TimeWindows.ofSizeWithNoGrace(Duration.parse(configProperties.aggregationWindowSize()));
+        TimeWindows tumblingWindow = TimeWindows.ofSizeWithNoGrace(configProperties.aggregationWindowSize());
 
         StreamsBuilder builder = new StreamsBuilder();
 

--- a/aggregator/src/test/java/io/spoud/kcc/aggregator/stream/TestConfigProperties.java
+++ b/aggregator/src/test/java/io/spoud/kcc/aggregator/stream/TestConfigProperties.java
@@ -3,6 +3,7 @@ package io.spoud.kcc.aggregator.stream;
 import io.spoud.kcc.aggregator.CostControlConfigProperties;
 import lombok.Builder;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -21,10 +22,10 @@ public class TestConfigProperties implements CostControlConfigProperties {
     private Map<String, MissingKeyHandling> splitMetricAmongPrincipalsMissingKeyHandling;
     private String splitMetricAmongPrincipalsFallbackPrincipal;
     @Builder.Default
-    private String aggregationWindowSize = "PT1H";
+    private Duration aggregationWindowSize = Duration.parse("PT1H");
 
     @Override
-    public String aggregationWindowSize() {
+    public Duration aggregationWindowSize() {
         return aggregationWindowSize;
     }
 


### PR DESCRIPTION
In cost control, we expose the newest state of each aggregated metric as a Prometheus metric using micrometer gauges. The issue with this solution is that if a context changes, the old gauge with the old context will still stick around, forever stuck on the last value. This solution adds logic that periodically checks existing gauges and removes ones that have not been updated for a full aggregation period.