### PR TITLE
move sql out of java code and into dedicated files

### DIFF
--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -95,6 +95,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-qute</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-messaging-kafka</artifactId>
         </dependency>
         <dependency>

--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/graphql/data/MetricHistoryTO.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/graphql/data/MetricHistoryTO.java
@@ -23,6 +23,7 @@ public class MetricHistoryTO {
     @NonNull
     private String name;
 
+    @Deprecated // TODO this seems to always be empty? Remove?
     @NonNull
     private Map<String, String> context;
 

--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/olap/SqlTemplates.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/olap/SqlTemplates.java
@@ -1,0 +1,113 @@
+package io.spoud.kcc.aggregator.olap;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Set;
+
+@ApplicationScoped
+public class SqlTemplates {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Inject
+    Template initDb;
+
+    @Inject
+    Template getMetricNames;
+
+    @Inject
+    Template getAllJsonKeys;
+
+    @Inject
+    Template getAllJsonKeyValues;
+
+    @Inject
+    Template exportData;
+
+    @Inject
+    Template importData;
+
+    @Inject
+    Template getHistory;
+
+    @Inject
+    Template getHistoryGrouped;
+
+    @Inject
+    Template insertValues;
+
+    public PreparedStatement initDb(Connection conn) throws SQLException {
+        return conn.prepareStatement(initDb.render());
+    }
+
+    public PreparedStatement getMetricNames(Connection conn) throws SQLException {
+        return conn.prepareStatement(getMetricNames.render());
+    }
+
+    public PreparedStatement getAllJsonKeys(Connection conn, String column) throws SQLException {
+        TemplateInstance template = getAllJsonKeys.data("column", column);
+        return conn.prepareStatement(template.render());
+    }
+
+    public PreparedStatement getAllJsonKeyValues(Connection conn, String column, String key) throws SQLException {
+        TemplateInstance template = getAllJsonKeyValues.data("column", column, "key", key);
+        return conn.prepareStatement(template.render());
+    }
+
+    public PreparedStatement exportData(Connection conn,
+                                        Path tmpFileName,
+                                        String finalFormat,
+                                        Instant from, Instant to) throws SQLException {
+        TemplateInstance template = exportData.data("tmpFileName", tmpFileName, "finalFormat", finalFormat);
+        var stmt = conn.prepareStatement(template.render());
+        stmt.setObject(1, from.atOffset(ZoneOffset.UTC));
+        stmt.setObject(2, to.atOffset(ZoneOffset.UTC));
+        return stmt;
+    }
+
+    public PreparedStatement importData(Connection conn, Path filename) throws SQLException {
+        return conn.prepareStatement(importData.data("path", filename).render());
+    }
+
+    public PreparedStatement getHistory(Connection conn, Set<String> metricNames,
+                                        Instant from, Instant to) throws SQLException {
+        TemplateInstance template = getHistory.data("metricNames", metricNames);
+        var stmt = conn.prepareStatement(template.render());
+        stmt.setObject(1, from.atOffset(ZoneOffset.UTC));
+        stmt.setObject(2, to.atOffset(ZoneOffset.UTC));
+        var i = 3;
+        for (var name : metricNames) {
+            stmt.setString(i++, name);
+        }
+        return stmt;
+    }
+
+    public PreparedStatement getHistoryGrouped(Connection conn, boolean groupByHour, Set<String> metricNames,
+                                               Instant from, Instant to, String groupByContextKey) throws SQLException {
+        var template = getHistoryGrouped.data("groupByHour", groupByHour, "metricNames", metricNames);
+        var stmt = conn.prepareStatement(template.render());
+        stmt.setObject(1, from.atOffset(ZoneOffset.UTC));
+        stmt.setObject(2, to.atOffset(ZoneOffset.UTC));
+        var i = 3;
+        for (var name : metricNames) {
+            stmt.setString(i++, name);
+        }
+        stmt.setString(i, groupByContextKey);
+        return stmt;
+    }
+
+    public PreparedStatement insertValues(Connection conn) throws SQLException {
+        String sql = insertValues.render();
+        var stmt = conn.prepareStatement(sql);
+        return stmt;
+    }
+}

--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/olap/SqlTemplates.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/olap/SqlTemplates.java
@@ -16,8 +16,6 @@ import java.util.Set;
 
 @ApplicationScoped
 public class SqlTemplates {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
     @Inject
     Template initDb;
 

--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/olap/SqlTemplates.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/olap/SqlTemplates.java
@@ -93,13 +93,13 @@ public class SqlTemplates {
                                                Instant from, Instant to, String groupByContextKey) throws SQLException {
         var template = getHistoryGrouped.data("groupByHour", groupByHour, "metricNames", metricNames);
         var stmt = conn.prepareStatement(template.render());
-        stmt.setObject(1, from.atOffset(ZoneOffset.UTC));
-        stmt.setObject(2, to.atOffset(ZoneOffset.UTC));
-        var i = 3;
+        stmt.setObject(1, groupByContextKey);
+        stmt.setObject(2, from.atOffset(ZoneOffset.UTC));
+        stmt.setObject(3, to.atOffset(ZoneOffset.UTC));
+        var i = 4;
         for (var name : metricNames) {
             stmt.setString(i++, name);
         }
-        stmt.setString(i, groupByContextKey);
         return stmt;
     }
 

--- a/aggregator/src/main/resources/application.yaml
+++ b/aggregator/src/main/resources/application.yaml
@@ -55,6 +55,8 @@ avro:
       imports: entity-type-enum.avsc
 
 quarkus:
+  qute:
+    suffixes: sql
   kafka-streams:
     application-id: ${kafka.application.id}
     topics: ${cc.topics.raw-data},${cc.topics.context-data},${cc.topics.pricing-rules},${cc.topics.aggregated}

--- a/aggregator/src/main/resources/templates/exportData.sql
+++ b/aggregator/src/main/resources/templates/exportData.sql
@@ -1,0 +1,8 @@
+COPY(
+    SELECT *
+    FROM aggregated_data
+    WHERE start_time >= ? AND end_time <= ?
+) TO '{tmpFileName}'
+{#if finalFormat == 'csv'}
+    (HEADER, DELIMITER ',')
+{/if}

--- a/aggregator/src/main/resources/templates/getAllJsonKeyValues.sql
+++ b/aggregator/src/main/resources/templates/getAllJsonKeyValues.sql
@@ -1,0 +1,1 @@
+SELECT DISTINCT {column}->>'{key}' FROM aggregated_data

--- a/aggregator/src/main/resources/templates/getAllJsonKeys.sql
+++ b/aggregator/src/main/resources/templates/getAllJsonKeys.sql
@@ -1,0 +1,1 @@
+SELECT unnest(json_keys( {column} )) FROM aggregated_data

--- a/aggregator/src/main/resources/templates/getHistory.sql
+++ b/aggregator/src/main/resources/templates/getHistory.sql
@@ -1,7 +1,9 @@
 SELECT * FROM aggregated_data
 WHERE start_time >= ? AND end_time <= ?
+    {#if metricNames.size > 0}
     AND initial_metric_name IN (
         {#each metricNames}
             ?{#if it_hasNext}, {/if}
         {/each}
     )
+    {/if}

--- a/aggregator/src/main/resources/templates/getHistory.sql
+++ b/aggregator/src/main/resources/templates/getHistory.sql
@@ -1,0 +1,7 @@
+SELECT * FROM aggregated_data
+WHERE start_time >= ? AND end_time <= ?
+    AND initial_metric_name IN (
+        {#each metricNames}
+            ?{#if it_hasNext}, {/if}
+        {/each}
+    )

--- a/aggregator/src/main/resources/templates/getHistoryGrouped.sql
+++ b/aggregator/src/main/resources/templates/getHistoryGrouped.sql
@@ -4,11 +4,13 @@
          SELECT json_value(context, ?) as context, start_time, value
          FROM aggregated_data
          WHERE start_time >= ? and end_time <= ?
+           {#if metricNames.size > 0}
            AND initial_metric_name IN (
              {#each metricNames}
                 ?{#if it_hasNext}, {/if}
              {/each}
-            )
+           )
+           {/if}
         ) as subquery
     GROUP BY context, start_time
     ORDER BY start_time
@@ -18,11 +20,13 @@
          SELECT json_value(context, ?) as context, start_time, value
          FROM aggregated_data
          WHERE start_time >= ? and end_time <= ?
+           {#if metricNames.size > 0}
            AND initial_metric_name IN (
              {#each metricNames}
                 ?{#if it_hasNext}, {/if}
              {/each}
-             )
+           )
+           {/if}
          ) as subquery
     GROUP BY context
 {/if}

--- a/aggregator/src/main/resources/templates/getHistoryGrouped.sql
+++ b/aggregator/src/main/resources/templates/getHistoryGrouped.sql
@@ -1,0 +1,28 @@
+{#if groupByHour}
+    SELECT subquery.context, subquery.start_time, SUM(subquery.value) as sum
+    FROM (
+         SELECT json_value(context, ?) as context, start_time, value
+         FROM aggregated_data
+         WHERE start_time >= ? and end_time <= ?
+           AND initial_metric_name IN (
+             {#each metricNames}
+                ?{#if it_hasNext}, {/if}
+             {/each}
+            )
+        ) as subquery
+    GROUP BY context, start_time
+    ORDER BY start_time
+{#else}
+    SELECT subquery.context, SUM(subquery.value) as sum
+    FROM (
+         SELECT json_value(context, ?) as context, start_time, value
+         FROM aggregated_data
+         WHERE start_time >= ? and end_time <= ?
+           AND initial_metric_name IN (
+             {#each metricNames}
+                ?{#if it_hasNext}, {/if}
+             {/each}
+             )
+         ) as subquery
+    GROUP BY context
+{/if}

--- a/aggregator/src/main/resources/templates/getMetricNames.sql
+++ b/aggregator/src/main/resources/templates/getMetricNames.sql
@@ -1,0 +1,1 @@
+SELECT DISTINCT initial_metric_name FROM aggregated_data;

--- a/aggregator/src/main/resources/templates/importData.sql
+++ b/aggregator/src/main/resources/templates/importData.sql
@@ -1,0 +1,1 @@
+COPY aggregated_data FROM '{path}' (AUTO_DETECT true)

--- a/aggregator/src/main/resources/templates/initDb.sql
+++ b/aggregator/src/main/resources/templates/initDb.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS aggregated_data (
+   start_time TIMESTAMPTZ NOT NULL,
+   end_time TIMESTAMPTZ NOT NULL,
+   initial_metric_name VARCHAR NOT NULL,
+   entity_type VARCHAR NOT NULL,
+   name VARCHAR NOT NULL,
+   tags JSON NOT NULL,
+   context JSON NOT NULL,
+   value DOUBLE NOT NULL,
+   target VARCHAR NOT NULL,
+   id VARCHAR PRIMARY KEY
+)

--- a/aggregator/src/main/resources/templates/insertValues.sql
+++ b/aggregator/src/main/resources/templates/insertValues.sql
@@ -1,0 +1,3 @@
+INSERT OR REPLACE INTO
+    aggregated_data (start_time, end_time, initial_metric_name, entity_type, name, tags, context, value, target, id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/aggregator/src/test/resources/application.yaml
+++ b/aggregator/src/test/resources/application.yaml
@@ -10,6 +10,8 @@ quarkus:
       dir: /tmp/kafka-stream-${quarkus.uuid}
 
 cc:
+  olap:
+    enabled: true
   metrics:
     aggregations:
       confluent_kafka_server_retained_bytes: max


### PR DESCRIPTION
This PR moves all the ugly SQL-concatenations out of the java code and into Qute templates. These are loaded in the `SqlTemplates` class which provides a type-safe way for turning these templates into prepared statements. Some of the SQL makes sense as a prepared statement (e.g. `INSERT...`) and some probably does not (e.g. `CREATE TABLE...`). For now, all SQL is returned as a prepared statement for the sake of consistency, but I'd love to discuss whether this is the best approach.