### PR TITLE
Fix/frontend tests

### DIFF
--- a/.github/workflows/build-frontend.yaml
+++ b/.github/workflows/build-frontend.yaml
@@ -42,6 +42,10 @@ jobs:
         working-directory: frontend/
         run: npm run build
 
+      - name: Test
+        working-directory: frontend/
+        run: npm test
+
       - name: Lint
         working-directory: frontend/
         run: npm run lint

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -83,10 +83,6 @@
         "test": {
           "builder": "@angular/build:karma",
           "options": {
-            "polyfills": [
-              "zone.js",
-              "zone.js/testing"
-            ],
             "tsConfig": "tsconfig.spec.json",
             "inlineStyleLanguage": "scss",
             "assets": [

--- a/frontend/src/app/auth/basic-auth-service.service.spec.ts
+++ b/frontend/src/app/auth/basic-auth-service.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { ApolloTestingModule } from 'apollo-angular/testing';
 
 import { BasicAuthServiceService } from './basic-auth-service.service';
 
@@ -6,7 +7,9 @@ describe('BasicAuthServiceService', () => {
     let service: BasicAuthServiceService;
 
     beforeEach(() => {
-        TestBed.configureTestingModule({});
+        TestBed.configureTestingModule({
+            imports: [ApolloTestingModule],
+        });
         service = TestBed.inject(BasicAuthServiceService);
     });
 

--- a/frontend/src/app/common/intl-date.pipe.spec.ts
+++ b/frontend/src/app/common/intl-date.pipe.spec.ts
@@ -1,10 +1,22 @@
+import { LOCALE_ID } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { IntlDatePipe } from './intl-date.pipe';
-import { IntlDateService } from '../services/intl-date.service';
-
-const service = new IntlDateService('de-CH', 'en-US');
-const pipe = new IntlDatePipe(service);
+import { BROWSER_LOCALE } from '../app.config';
 
 describe('IntlDatePipe', () => {
+    let pipe: IntlDatePipe;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                IntlDatePipe,
+                { provide: BROWSER_LOCALE, useValue: 'de-CH' },
+                { provide: LOCALE_ID, useValue: 'en-US' },
+            ],
+        });
+        pipe = TestBed.inject(IntlDatePipe);
+    });
+
     it('create an instance', () => {
         expect(pipe).toBeTruthy();
     });


### PR DESCRIPTION
Fix dangling test failures from angular 21 zoneless migration.
They were invisible since CI never ran the tests, so I added `npm test` step to the pipeline

(this PR is based on #749,)