### PR TITLE
feat(helm): add schema registry basic auth credentials support

### DIFF
--- a/helm/kcc-strimzi/templates/aggregator.yaml
+++ b/helm/kcc-strimzi/templates/aggregator.yaml
@@ -84,6 +84,22 @@ spec:
               value: {{ .Values.aggregator.appId }}
             - name: KAFKA_SCHEMA_REGISTRY_URL
               value: {{ .Values.schemaRegistry.url }}
+            {{- if .Values.schemaRegistry.basicAuthCredentials }}
+            - name: SCHEMA_REGISTRY_BASIC_AUTH_CREDENTIALS_SOURCE
+              value: "USER_INFO"
+            - name: SCHEMA_REGISTRY_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.schemaRegistry.basicAuthCredentials.secretName }}
+                  key: {{ .Values.schemaRegistry.basicAuthCredentials.usernameKey }}
+            - name: SCHEMA_REGISTRY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.schemaRegistry.basicAuthCredentials.secretName }}
+                  key: {{ .Values.schemaRegistry.basicAuthCredentials.passwordKey }}
+            - name: SCHEMA_REGISTRY_USER_INFO
+              value: "{{ required "schemaRegistry.basicAuthCredentials.usernameKey is required when basicAuthCredentials is set" .Values.schemaRegistry.basicAuthCredentials.usernameKey }}:{{ required "schemaRegistry.basicAuthCredentials.passwordKey is required when basicAuthCredentials is set" .Values.schemaRegistry.basicAuthCredentials.passwordKey }}"
+            {{- end }}
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: {{ .Values.strimzi.bootstrapServer }}
             - name: CC_TOPICS_PRICING_RULES

--- a/helm/kcc-strimzi/templates/context-operator.yaml
+++ b/helm/kcc-strimzi/templates/context-operator.yaml
@@ -156,6 +156,22 @@ spec:
           value: "false"
         - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_SCHEMA_REGISTRY_URL
           value: {{ .Values.schemaRegistry.url }}
+        {{- if .Values.schemaRegistry.basicAuthCredentials }}
+        - name: SCHEMA_REGISTRY_BASIC_AUTH_CREDENTIALS_SOURCE
+          value: "USER_INFO"
+        - name: SCHEMA_REGISTRY_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.schemaRegistry.basicAuthCredentials.secretName }}
+              key: {{ .Values.schemaRegistry.basicAuthCredentials.usernameKey }}
+        - name: SCHEMA_REGISTRY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.schemaRegistry.basicAuthCredentials.secretName }}
+              key: {{ .Values.schemaRegistry.basicAuthCredentials.passwordKey }}
+        - name: SCHEMA_REGISTRY_USER_INFO
+          value: "{{ required "schemaRegistry.basicAuthCredentials.usernameKey is required when basicAuthCredentials is set" .Values.schemaRegistry.basicAuthCredentials.usernameKey }}:{{ required "schemaRegistry.basicAuthCredentials.passwordKey is required when basicAuthCredentials is set" .Values.schemaRegistry.basicAuthCredentials.passwordKey }}"
+        {{- end }}
         - name: MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS
           value: {{ .Values.strimzi.bootstrapServer }}
         - name: CC_STRIMZI_OPERATOR_TOPICS_CONTEXT_DATA

--- a/helm/kcc-strimzi/templates/timescaledb.yaml
+++ b/helm/kcc-strimzi/templates/timescaledb.yaml
@@ -222,6 +222,22 @@ spec:
     connectContainer:
       env:
         {{- .Values.connect.env | toYaml | nindent 8 }}
+        {{- if .Values.schemaRegistry.basicAuthCredentials }}
+        - name: SCHEMA_REGISTRY_BASIC_AUTH_CREDENTIALS_SOURCE
+          value: "USER_INFO"
+        - name: SCHEMA_REGISTRY_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.schemaRegistry.basicAuthCredentials.secretName }}
+              key: {{ .Values.schemaRegistry.basicAuthCredentials.usernameKey }}
+        - name: SCHEMA_REGISTRY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.schemaRegistry.basicAuthCredentials.secretName }}
+              key: {{ .Values.schemaRegistry.basicAuthCredentials.passwordKey }}
+        - name: SCHEMA_REGISTRY_USER_INFO
+          value: "{{ required "schemaRegistry.basicAuthCredentials.usernameKey is required when basicAuthCredentials is set" .Values.schemaRegistry.basicAuthCredentials.usernameKey }}:{{ required "schemaRegistry.basicAuthCredentials.passwordKey is required when basicAuthCredentials is set" .Values.schemaRegistry.basicAuthCredentials.passwordKey }}"
+        {{- end }}
     pod:
       metadata:
         labels:
@@ -291,7 +307,7 @@ spec:
     "value.converter": "io.confluent.connect.avro.AvroConverter",
     "value.converter.schema.registry.url": "{{ .Values.schemaRegistry.url }}",
     "value.converter.basic.auth.credentials.source": "USER_INFO",
-    "value.converter.basic.auth.user.info": "schema-registry-user:schema-registry-password",
+    "value.converter.basic.auth.user.info": "${env:SCHEMA_REGISTRY_USER_INFO}",
     "transforms": "flatten",
     "transforms.flatten.type": "org.apache.kafka.connect.transforms.Flatten$Value",
     "transforms.flatten.delimiter": "_"

--- a/helm/kcc-strimzi/values.yaml
+++ b/helm/kcc-strimzi/values.yaml
@@ -111,6 +111,19 @@ strimzi:
 # kubectl expose deploy schema-registry
 schemaRegistry:
   url: http://schema-registry:8080/apis/ccompat/v7
+  # Schema registry authentication (basic auth).
+  # If you have a secret with the credentials, uncomment and set the following:
+  # basicAuthCredentials:
+  #   secretName: my-secret
+  #   usernameKey: username
+  #   passwordKey: password
+  # This will add the following environment variables to all components that use schema registry:
+  #   SCHEMA_REGISTRY_USERNAME  (from secret)
+  #   SCHEMA_REGISTRY_PASSWORD  (from secret)
+  #   SCHEMA_REGISTRY_BASIC_AUTH_CREDENTIALS_SOURCE (value: "USER_INFO")
+  #   SCHEMA_REGISTRY_USER_INFO (value: "<username>:<password>")
+  # The connector config will also be updated to use these credentials.
+  basicAuthCredentials: { }
 
 aggregator:
   enabled: true


### PR DESCRIPTION
## Summary

Closes #284

Adds basic authentication support for schema registry across all components that consume from it:

- **Strimzi Context Operator** — Deployment template
- **Aggregator** — StatefulSet template  
- **Kafka Connect** — KafkaConnect CR (timescaledb.yaml)

## Changes

### 
Added optional  block under :

```yaml
schemaRegistry:
  url: http://schema-registry:8080/apis/ccompat/v7
  basicAuthCredentials:
    secretName: my-secret
    usernameKey: username
    passwordKey: password
```

### Templates
When  is set, all three components receive these environment variables:

| Variable | Source |
|----------|--------|
| `SCHEMA_REGISTRY_BASIC_AUTH_CREDENTIALS_SOURCE` | `USER_INFO` |
| `SCHEMA_REGISTRY_USERNAME` | From secret |
| `SCHEMA_REGISTRY_PASSWORD` | From secret |
| `SCHEMA_REGISTRY_USER_INFO` | `<username>:<password>` |

### KafkaConnector (TimescaleDB Sink)
Updated `value.converter.basic.auth.user.info` to use `${env:SCHEMA_REGISTRY_USER_INFO}` instead of hardcoded credentials, so the Connect worker picks up credentials from its environment.

## Usage

1. Create a secret with your schema registry credentials:

```bash
kubectl create secret generic schema-registry-creds \  --from-literal=username=your-username \  --from-literal=password=your-password
```

2. Reference it in `values.yaml`:

```yaml
schemaRegistry:
  url: https://schema-registry.example.com/apis/ccompat/v7
  basicAuthCredentials:
    secretName: schema-registry-creds
    usernameKey: username
    passwordKey: password
```

## Testing

The templates use `required()` to validate that `usernameKey` and `passwordKey` are set when `basicAuthCredentials` is defined. Helm will fail early with a clear error if the secret keys are missing.