### PR TITLE
Skip Docker Hub login in build-kafka-connect on pull_request events

### DIFF
--- a/.github/workflows/build-kafka-connect.yaml
+++ b/.github/workflows/build-kafka-connect.yaml
@@ -35,6 +35,7 @@ jobs:
 
   build_confluent:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -70,6 +71,7 @@ jobs:
 
   build_strimzi:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Summary
- `build_confluent`/`build_strimzi` in `build-kafka-connect.yaml` are meant to be the push-event-only deploy path (per the job's own comment), but neither job had a condition enforcing that.
- The unconditional "Login to Docker Hub" step ran on every PR too, failing with `Username and password required` since PR-triggered runs don't have access to repo secrets — spuriously red-X'ing PRs that only bump action/dependency versions (e.g. #835, #833).
- Adds `if: github.event_name == 'push'` at the job level to both jobs so they're skipped entirely on `pull_request` events.

No loss of PR-time build validation: the separate `build` job already builds both Dockerfiles with `push: false` on every PR.

## Test plan
- [ ] Confirm this PR's own `build_confluent`/`build_strimzi` checks show as skipped (not failed)
- [ ] After merge, verify a push to master still runs `build_confluent`/`build_strimzi` and pushes images normally
- [ ] Re-check #835 and #833 once master has this fix