### PR TITLE
fix: OLAP row buffer overflow crashes Kafka Streams client

### DIFF
--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/olap/AggregatedMetricsRepository.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/olap/AggregatedMetricsRepository.java
@@ -161,7 +161,12 @@ public class AggregatedMetricsRepository {
         if (!olapConfig.enabled()) {
             return;
         }
-        rowBuffer.add(row);
+        try {
+            rowBuffer.put(row);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+        }
         if (rowBuffer.size() >= olapConfig.databaseMaxBufferedRows()) {
             CompletableFuture.runAsync(() -> {
                 try {


### PR DESCRIPTION
## Summary
- `kafka-cost-control-0` in `kafka-cost-control-demo` was stuck in `CrashLoopBackOff` (44 restarts / 22h).
- Root cause: `AggregatedMetricsRepository.insertRow()` used a non-blocking `rowBuffer.add()` on the bounded OLAP row buffer. When metrics arrived faster than DuckDB could drain them, it threw `IllegalStateException: Queue full` inside the Kafka Streams topology (`insert-into-olap-db` peek in `MetricEnricher`). Kafka Streams treats an uncaught processing exception as fatal and shuts the whole client down, which fails health checks and gets the pod killed/restarted — repeating on the same burst after restart.
- Fix: switch to blocking `rowBuffer.put()` so the Streams thread applies natural backpressure instead of crashing.

## Test plan
- [x] `AggregatedMetricsRepositoryTest` and `MetricEnricherTest` pass locally
- [ ] Deploy to `kafka-cost-control-demo` and confirm the pod stops crash-looping