### PR TITLE
fix: gauge tag-key mismatch across topics/principals with uneven context-data coverage

### DIFF
--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/repository/GaugeRepository.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/repository/GaugeRepository.java
@@ -14,13 +14,20 @@ import lombok.Data;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /** Store all the metric values (gauges) observed while running the application. */
 @ApplicationScoped
 public class GaugeRepository {
     private final Map<GaugeKey, GaugeInfo> gauges = new ConcurrentHashMap<>();
+    // Prometheus requires every series registered under the same gauge name to share the same tag key set.
+    // Since context-data rules can attach a different subset of keys to different topics/principals, we track
+    // the widest key set seen so far per gauge name and pad every update to match it, growing it (and re-registering
+    // already-known gauges under that name) whenever a new key shows up.
+    private final Map<String, Set<String>> tagKeysByGaugeName = new ConcurrentHashMap<>();
     private final MeterRegistry meterRegistry;
     private final Duration gaugeTimeout;
     private Instant currentTime = Instant.MIN;
@@ -31,15 +38,60 @@ public class GaugeRepository {
         this.gaugeTimeout = configProperties.aggregationWindowSize().plus(Duration.ofSeconds(30));
     }
 
-    public void updateGauge(String name, Tags tags, double value, Instant eventTime) {
-        var key = new GaugeKey(name, tags);
+    public synchronized void updateGauge(String name, Tags tags, double value, Instant eventTime) {
         updateCurrentTime(eventTime);
-        gauges.computeIfAbsent(key, g -> {
-            var atomicDouble = new AtomicDouble(value);
-            var id = Gauge.builder(name, atomicDouble, AtomicDouble::get).tags(tags).register(meterRegistry).getId();
-            var timeout = getCurrentTime().plus(gaugeTimeout);
-            return new GaugeInfo(id, atomicDouble, timeout);
-        }).updateValue(value);
+        var tagKeys = tagKeysByGaugeName.computeIfAbsent(name, n -> tagKeys(tags));
+        if (!tagKeys.containsAll(tagKeys(tags))) {
+            tagKeys = new LinkedHashSet<>(tagKeys);
+            tagKeys.addAll(tagKeys(tags));
+            tagKeysByGaugeName.put(name, tagKeys);
+            widenExistingGauges(name, tagKeys);
+        }
+        var paddedTags = padTags(tags, tagKeys);
+        var key = new GaugeKey(name, paddedTags);
+        gauges.computeIfAbsent(key, g -> registerGauge(name, paddedTags, value, getCurrentTime().plus(gaugeTimeout)))
+                .updateValue(value);
+    }
+
+    /** Re-registers every existing gauge under {@code name} so all of them share the new, wider tag key set. */
+    private void widenExistingGauges(String name, Set<String> tagKeys) {
+        gauges.entrySet().stream()
+                .filter(entry -> entry.getKey().name().equals(name))
+                .toList()
+                .forEach(entry -> {
+                    var oldKey = entry.getKey();
+                    var newTags = padTags(oldKey.tags(), tagKeys);
+                    if (newTags.equals(oldKey.tags())) {
+                        return;
+                    }
+                    var info = entry.getValue();
+                    meterRegistry.remove(info.getId());
+                    gauges.remove(oldKey);
+                    gauges.put(new GaugeKey(name, newTags), registerGauge(name, newTags, info.getGaugeValue().get(), info.getTimeout()));
+                });
+    }
+
+    private GaugeInfo registerGauge(String name, Tags tags, double value, Instant timeout) {
+        var atomicDouble = new AtomicDouble(value);
+        var id = Gauge.builder(name, atomicDouble, AtomicDouble::get).tags(tags).register(meterRegistry).getId();
+        return new GaugeInfo(id, atomicDouble, timeout);
+    }
+
+    private static Set<String> tagKeys(Tags tags) {
+        var keys = new LinkedHashSet<String>();
+        tags.forEach(tag -> keys.add(tag.getKey()));
+        return keys;
+    }
+
+    private static Tags padTags(Tags tags, Set<String> keys) {
+        var existingKeys = tagKeys(tags);
+        var result = tags;
+        for (var key : keys) {
+            if (!existingKeys.contains(key)) {
+                result = result.and(key, "");
+            }
+        }
+        return result;
     }
 
     public Map<GaugeKey, Double> getGaugeValues() {
@@ -49,7 +101,7 @@ public class GaugeRepository {
     }
 
     @Scheduled(every = "60s", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
-    public void removeExpiredGauges() {
+    public synchronized void removeExpiredGauges() {
         var now = getCurrentTime();
         gauges.entrySet().removeIf(entry -> {
             if (entry.getValue().getTimeout().isBefore(now)) {

--- a/aggregator/src/test/java/io/spoud/kcc/aggregator/repository/GaugeRepositoryTest.java
+++ b/aggregator/src/test/java/io/spoud/kcc/aggregator/repository/GaugeRepositoryTest.java
@@ -1,0 +1,79 @@
+package io.spoud.kcc.aggregator.repository;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.spoud.kcc.aggregator.CostControlConfigProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+class GaugeRepositoryTest {
+
+    private PrometheusMeterRegistry meterRegistry;
+    private GaugeRepository gaugeRepository;
+
+    @BeforeEach
+    void setup() {
+        meterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        var configProperties = Mockito.mock(CostControlConfigProperties.class);
+        when(configProperties.aggregationWindowSize()).thenReturn(Duration.ofHours(1));
+        gaugeRepository = new GaugeRepository(meterRegistry, configProperties);
+    }
+
+    @Test
+    void updatingGaugeWithFewerTagsThanAnExistingSeriesDoesNotThrow() {
+        gaugeRepository.updateGauge("kcc_test_metric", Tags.of("topic", "topicA", "app", "app1"), 10.0, Instant.now());
+
+        // topicB has no matching context-data rule for "app", so it reports fewer tag keys than topicA.
+        // Without widening, Micrometer's PrometheusMeterRegistry would throw IllegalArgumentException here.
+        gaugeRepository.updateGauge("kcc_test_metric", Tags.of("topic", "topicB"), 20.0, Instant.now());
+
+        var gauges = meterRegistry.find("kcc_test_metric").gauges();
+        assertThat(gauges).hasSize(2);
+
+        var topicAValue = meterRegistry.find("kcc_test_metric").tag("topic", "topicA").gauge();
+        var topicBValue = meterRegistry.find("kcc_test_metric").tag("topic", "topicB").gauge();
+        assertThat(topicAValue).isNotNull();
+        assertThat(topicBValue).isNotNull();
+        assertThat(topicAValue.value()).isEqualTo(10.0);
+        assertThat(topicBValue.value()).isEqualTo(20.0);
+        // topicB is padded with an empty "app" tag so it shares topicA's key set.
+        assertThat(topicBValue.getId().getTag("app")).isEqualTo("");
+    }
+
+    @Test
+    void updatingGaugeWithANewTagKeyWidensAlreadyRegisteredSeries() {
+        gaugeRepository.updateGauge("kcc_test_metric", Tags.of("topic", "topicA"), 10.0, Instant.now());
+
+        // topicC introduces a brand-new key ("domain") that topicA was never registered with.
+        gaugeRepository.updateGauge("kcc_test_metric", Tags.of("topic", "topicC", "domain", "sales"), 30.0, Instant.now());
+
+        var topicAGauge = meterRegistry.find("kcc_test_metric").tag("topic", "topicA").gauge();
+        var topicCGauge = meterRegistry.find("kcc_test_metric").tag("topic", "topicC").gauge();
+        assertThat(topicAGauge).isNotNull();
+        assertThat(topicCGauge).isNotNull();
+        // topicA's value survives being re-registered under the widened tag set.
+        assertThat(topicAGauge.value()).isEqualTo(10.0);
+        assertThat(topicAGauge.getId().getTag("domain")).isEqualTo("");
+        assertThat(topicCGauge.value()).isEqualTo(30.0);
+
+        // No stale/orphaned meters left behind from the re-registration.
+        assertThat(meterRegistry.find("kcc_test_metric").gauges()).hasSize(2);
+    }
+
+    @Test
+    void updatingSameTagsTwiceUpdatesValueInPlace() {
+        gaugeRepository.updateGauge("kcc_test_metric", Tags.of("topic", "topicA"), 10.0, Instant.now());
+        gaugeRepository.updateGauge("kcc_test_metric", Tags.of("topic", "topicA"), 15.0, Instant.now());
+
+        assertThat(meterRegistry.find("kcc_test_metric").gauges()).hasSize(1);
+        assertThat(meterRegistry.find("kcc_test_metric").gauge().value()).isEqualTo(15.0);
+    }
+}


### PR DESCRIPTION
## Summary
- Multiple Kafka topics/principals share one Micrometer/Prometheus gauge name (`kcc_<initialMetricName>`), but `context-data` rules only attach a subset of context keys to some of them (and entity type adds its own key: `topic` vs `principal`). Prometheus requires every series under a gauge name to share an identical tag key set — whichever entity registered first "won" that shape, and every subsequent update carrying a different key set was silently dropped (visible now thanks to #843's logging fix):
  > `Prometheus requires that all meters with the same name have the same set of tag keys. There is already an existing meter named 'kcc_confluent_kafka_server_retained_bytes' containing tag keys [app, cost_unit, domain, format, topic]. The meter you are attempting to register has keys [app, format, topic].`
- This means some topics/principals were permanently missing from these gauges in `/q/metrics`.

## Fix
`GaugeRepository` now tracks the widest tag-key set seen so far per gauge name. Whenever an update introduces a previously-unseen key, it widens that set and **re-registers every existing series under that name** with the new key set (padding missing keys with an empty value), instead of failing. This is adaptive rather than a one-time snapshot — it keeps working correctly even if `context-data` rules are added/changed later at runtime, not just for keys known today.

No behavior change to cost calculation/aggregation/OLAP — this only affects the `kcc_*` Prometheus gauge exposition at `/q/metrics`.

## Test plan
- [x] New `GaugeRepositoryTest` reproduces the real conflict against an actual `PrometheusMeterRegistry` (not a permissive `SimpleMeterRegistry`) and verifies: narrower/wider tag sets no longer throw, existing series get migrated with their values preserved, and repeated updates with the same tags still update in place.
- [x] Full `mvn test` suite passes (65 tests, 0 failures)