### PR TITLE
Fix strimzi-operator dependabot PRs getting stuck on required build check

### DIFF
--- a/.github/workflows/build-operator.yaml
+++ b/.github/workflows/build-operator.yaml
@@ -10,7 +10,7 @@ on:
     paths: ['strimzi-operator/**', '.github/workflows/build-operator.yaml']
 
 jobs:
-  build:
+  build-matrix:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -84,3 +84,20 @@ jobs:
           file: strimzi-operator/src/main/docker/Dockerfile.jvm
           push: true
           tags: spoud/kafka-cost-control-strimzi-operator:${{ env.VERSION }}${{ matrix.tag-suffix }}
+
+  # Aggregates the matrix legs above into a single check named "build", matching the job id used by every
+  # other build-*.yaml workflow. Branch protection requires a status check literally named "build"; a matrix
+  # job's check name always gets suffixed with its matrix values (e.g. "build-matrix (v1, verify, ...)"), so
+  # without this job no workflow ever posts a plain "build" check for PRs that only touch strimzi-operator/**,
+  # leaving the required check stuck on "Expected" forever regardless of the actual build outcome.
+  build:
+    needs: build-matrix
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check matrix result
+        run: |
+          if [ "${{ needs.build-matrix.result }}" != "success" ]; then
+            echo "build-matrix failed: ${{ needs.build-matrix.result }}"
+            exit 1
+          fi

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -4,6 +4,7 @@ on:
     paths:
       - 'frontend/**'
       - 'aggregator/**'
+      - 'strimzi-operator/**'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Problem

PR #846 (and its recently-merged siblings #848/#850) needed a manual branch-protection bypass to merge despite green CI and an approval. Root cause:

1. **`master` branch protection requires a status check literally named `build`.** Every `build-*.yaml` workflow has a job with id `build`, so that check gets posted — except `build-operator.yaml`, whose `build` job uses a `strategy.matrix`. GitHub Actions always suffixes matrix job check names with the matrix values (`build (v1, verify, -Pfailsafe)`, `build (v1beta2, ...)`), so a plain `build` check is *never* posted. For a PR that only touches `strimzi-operator/**` (the only workflow that runs), the required check sits on "Expected" forever regardless of the actual build result, and `mergeStateStatus` stays `BLOCKED`.
2. **`dependabot-auto-merge.yaml`'s path filter never included `strimzi-operator/**`** (only `frontend/**` and `aggregator/**`), so these PRs never got auto-approved/auto-merge-enabled even as a workaround.

## Fix

- `build-operator.yaml`: renamed the matrix job to `build-matrix` and added a `build` job that `needs: build-matrix` and fails if it didn't succeed — matching the job-id convention every other `build-*.yaml` already uses, so the required check gets posted correctly.
- `dependabot-auto-merge.yaml`: added `strimzi-operator/**` to the trigger paths so these dependabot PRs get auto-approved and auto-merged like the frontend/aggregator ones.

## Test plan
- [ ] Confirm this PR's own "Build operator" run now posts a check named exactly `build` (in addition to the matrix-named ones) with a success conclusion.
- [ ] After merge, confirm a future `strimzi-operator`-only dependabot PR gets auto-approved, has auto-merge enabled, and merges on its own without an admin bypass.