### PR TITLE
fix: harden gauge tag-key widening against partial failures and lock gaps

### DIFF
--- a/aggregator/src/main/java/io/spoud/kcc/aggregator/repository/GaugeRepository.java
+++ b/aggregator/src/main/java/io/spoud/kcc/aggregator/repository/GaugeRepository.java
@@ -40,14 +40,15 @@ public class GaugeRepository {
 
     public synchronized void updateGauge(String name, Tags tags, double value, Instant eventTime) {
         updateCurrentTime(eventTime);
-        var tagKeys = tagKeysByGaugeName.computeIfAbsent(name, n -> tagKeys(tags));
-        if (!tagKeys.containsAll(tagKeys(tags))) {
+        var incomingKeys = tagKeys(tags);
+        var tagKeys = tagKeysByGaugeName.computeIfAbsent(name, n -> incomingKeys);
+        if (!tagKeys.containsAll(incomingKeys)) {
             tagKeys = new LinkedHashSet<>(tagKeys);
-            tagKeys.addAll(tagKeys(tags));
+            tagKeys.addAll(incomingKeys);
             tagKeysByGaugeName.put(name, tagKeys);
             widenExistingGauges(name, tagKeys);
         }
-        var paddedTags = padTags(tags, tagKeys);
+        var paddedTags = padTags(tags, incomingKeys, tagKeys);
         var key = new GaugeKey(name, paddedTags);
         gauges.computeIfAbsent(key, g -> registerGauge(name, paddedTags, value, getCurrentTime().plus(gaugeTimeout)))
                 .updateValue(value);
@@ -55,20 +56,32 @@ public class GaugeRepository {
 
     /** Re-registers every existing gauge under {@code name} so all of them share the new, wider tag key set. */
     private void widenExistingGauges(String name, Set<String> tagKeys) {
-        gauges.entrySet().stream()
+        record Widened(GaugeKey oldKey, GaugeInfo info, Tags newTags) {}
+        var toWiden = gauges.entrySet().stream()
                 .filter(entry -> entry.getKey().name().equals(name))
-                .toList()
-                .forEach(entry -> {
-                    var oldKey = entry.getKey();
-                    var newTags = padTags(oldKey.tags(), tagKeys);
-                    if (newTags.equals(oldKey.tags())) {
-                        return;
-                    }
-                    var info = entry.getValue();
-                    meterRegistry.remove(info.getId());
-                    gauges.remove(oldKey);
-                    gauges.put(new GaugeKey(name, newTags), registerGauge(name, newTags, info.getGaugeValue().get(), info.getTimeout()));
-                });
+                .map(entry -> new Widened(entry.getKey(), entry.getValue(),
+                        padTags(entry.getKey().tags(), tagKeys(entry.getKey().tags()), tagKeys)))
+                .filter(w -> !w.newTags().equals(w.oldKey().tags()))
+                .toList();
+        // Prometheus ties a gauge name to a single fixed tag-key shape until every series under it is
+        // removed. Removing and re-registering series one at a time would momentarily leave old- and
+        // new-shape series registered together under the same name and throw, so remove all of them
+        // first (fully draining the name) before registering any of them under the wider shape.
+        toWiden.forEach(w -> {
+            meterRegistry.remove(w.info().getId());
+            gauges.remove(w.oldKey());
+        });
+        toWiden.forEach(w -> {
+            try {
+                var info = w.info();
+                gauges.put(new GaugeKey(name, w.newTags()),
+                        registerGauge(name, w.newTags(), info.getGaugeValue().get(), info.getTimeout()));
+            } catch (Exception e) {
+                // Leave this one unregistered rather than aborting the remaining entries: it self-heals
+                // on the next matching updateGauge() call, which re-registers it via computeIfAbsent().
+                Log.warnv("Failed to re-register widened gauge '{0}' with tags '{1}': {2}", name, w.newTags(), e.getMessage());
+            }
+        });
     }
 
     private GaugeInfo registerGauge(String name, Tags tags, double value, Instant timeout) {
@@ -83,8 +96,7 @@ public class GaugeRepository {
         return keys;
     }
 
-    private static Tags padTags(Tags tags, Set<String> keys) {
-        var existingKeys = tagKeys(tags);
+    private static Tags padTags(Tags tags, Set<String> existingKeys, Set<String> keys) {
         var result = tags;
         for (var key : keys) {
             if (!existingKeys.contains(key)) {
@@ -94,7 +106,7 @@ public class GaugeRepository {
         return result;
     }
 
-    public Map<GaugeKey, Double> getGaugeValues() {
+    public synchronized Map<GaugeKey, Double> getGaugeValues() {
         var result = new ConcurrentHashMap<GaugeKey, Double>();
         gauges.forEach((key, value) -> result.put(key, value.gaugeValue.get()));
         return result;

--- a/aggregator/src/test/java/io/spoud/kcc/aggregator/repository/GaugeRepositoryTest.java
+++ b/aggregator/src/test/java/io/spoud/kcc/aggregator/repository/GaugeRepositoryTest.java
@@ -22,6 +22,11 @@ class GaugeRepositoryTest {
     @BeforeEach
     void setup() {
         meterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        // Micrometer's PrometheusMeterRegistry does not throw on tag-shape conflicts by default -- it
+        // silently drops the conflicting registration instead, which production currently relies on as
+        // a safety net. Opt into throwing here so these tests fail loudly if the widening logic
+        // regresses, instead of passing while quietly dropping data the way production would.
+        meterRegistry.throwExceptionOnRegistrationFailure();
         var configProperties = Mockito.mock(CostControlConfigProperties.class);
         when(configProperties.aggregationWindowSize()).thenReturn(Duration.ofHours(1));
         gaugeRepository = new GaugeRepository(meterRegistry, configProperties);
@@ -66,6 +71,28 @@ class GaugeRepositoryTest {
 
         // No stale/orphaned meters left behind from the re-registration.
         assertThat(meterRegistry.find("kcc_test_metric").gauges()).hasSize(2);
+    }
+
+    @Test
+    void updatingGaugeThatWidensMultiplePreRegisteredSeriesAtOnceDoesNotThrow() {
+        gaugeRepository.updateGauge("kcc_test_metric", Tags.of("topic", "topicA"), 10.0, Instant.now());
+        gaugeRepository.updateGauge("kcc_test_metric", Tags.of("topic", "topicB"), 20.0, Instant.now());
+
+        // topicC introduces a brand-new key ("domain"), forcing BOTH topicA and topicB to be widened
+        // in the same widenExistingGauges() call.
+        gaugeRepository.updateGauge("kcc_test_metric", Tags.of("topic", "topicC", "domain", "sales"), 30.0, Instant.now());
+
+        assertThat(meterRegistry.find("kcc_test_metric").gauges()).hasSize(3);
+    }
+
+    @Test
+    void widensManyPreRegisteredSeriesAtOnceDoesNotThrow() {
+        for (int i = 0; i < 20; i++) {
+            gaugeRepository.updateGauge("kcc_test_metric", Tags.of("topic", "topic" + i), i, Instant.now());
+        }
+        gaugeRepository.updateGauge("kcc_test_metric", Tags.of("topic", "topicNew", "domain", "sales"), 99.0, Instant.now());
+
+        assertThat(meterRegistry.find("kcc_test_metric").gauges()).hasSize(21);
     }
 
     @Test


### PR DESCRIPTION
## Summary
Follow-up to #859. Hardens `GaugeRepository`'s tag-key widening logic, which reconciles Prometheus's fixed-label-schema-per-metric-name requirement with context-data rules that attach different key sets to different topics/principals.

- `widenExistingGauges()` no longer aborts the whole re-registration batch if a single entry's `registerGauge()` throws — it logs and continues so later entries aren't left stranded unregistered.
- `getGaugeValues()` is now `synchronized`, consistent with the locking used by `updateGauge()`/`removeExpiredGauges()`.
- Removed duplicate `tagKeys()`/`padTags()` computation per entry during widening.
- Corrected a test comment that incorrectly claimed Quarkus enables `throwExceptionOnRegistrationFailure()` on the production registry.

This only touches the `/q/metrics` Prometheus gauge exposition path — cost calculation (pricing-rule join, OLAP, GraphQL) happens earlier in `MetricEnricher`'s pipeline and is unaffected.

## Test plan
- [x] `mvn test -Dtest=GaugeRepositoryTest` — 5/5 passing
- [x] `mvn test -Dtest=MetricEnricherTest` — 21/21 passing